### PR TITLE
Fixed unit conversions for test data

### DIFF
--- a/u_react/ios/Podfile.lock
+++ b/u_react/ios/Podfile.lock
@@ -92,13 +92,13 @@ SPEC CHECKSUMS:
   audioplayers_darwin: 877d9a4d06331c5c374595e46e16453ac7eafa40
   DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
   DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
-  file_picker: 15fd9539e4eb735dc54bae8c0534a7a9511a03de
+  file_picker: 09aa5ec1ab24135ccd7a1621c46c84134bfd6655
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_ringtone_player: 15eba85187230b87b2512f0e1b92225618bc03e7
-  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   SDWebImage: fc8f2d48bbfd72ef39d70e981bd24a3f3be53fec
-  sensors_plus: 42b9de1b8237675fa8d8121e4bb93be0f79fa61d
-  share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
+  sensors_plus: 18a9b346c43e157da17d2c8e99def703f9efb9d8
+  share_plus: 8875f4f2500512ea181eef553c3e27dba5135aad
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
   SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f
 

--- a/u_react/ios/Runner/Runner.entitlements
+++ b/u_react/ios/Runner/Runner.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>aps-environment</key>
-	<string>development</string>
-</dict>
+<dict/>
 </plist>

--- a/u_react/lib/dynamic_results_page.dart
+++ b/u_react/lib/dynamic_results_page.dart
@@ -203,28 +203,28 @@ class _DynamicResultsPage extends State<DynamicResultsPage> {
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.dMax.toString(),
+                                    widget.dMax.toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.dMin.toString(),
+                                    widget.dMin.toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.dMean.toString(),
+                                    widget.dMean.toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.dMedian.toString(),
+                                    widget.dMedian.toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
@@ -247,28 +247,28 @@ class _DynamicResultsPage extends State<DynamicResultsPage> {
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.tsMax.toString(),
+                                    widget.tsMax.toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.tsMin.toString(),
+                                    widget.tsMin.toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.tsMean.toString(),
+                                    widget.tsMean.toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.tsMedian.toString(),
+                                    widget.tsMedian.toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
@@ -291,28 +291,28 @@ class _DynamicResultsPage extends State<DynamicResultsPage> {
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.mlMax.toString(),
+                                    (widget.mlMax * 100).toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.mlMin.toString(),
+                                    (widget.mlMin * 100).toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.mlMean.toString(),
+                                    (widget.mlMean * 100).toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
                                 Expanded(
                                   flex: 2,
                                   child: Text(
-                                    widget.mlMedian.toString(),
+                                    (widget.mlMedian * 100).toStringAsFixed(3),
                                     textAlign: TextAlign.center,
                                   ),
                                 ),
@@ -352,14 +352,14 @@ class _DynamicResultsPage extends State<DynamicResultsPage> {
                               ListTile(
                                 title: const Text('Duration (s)'),
                                 trailing: Text(
-                                  widget.t1Duration.toString(),
+                                  widget.t1Duration.toStringAsFixed(3),
                                   style: const TextStyle(fontSize: 15),
                                 ),
                               ),
                               ListTile(
                                 title: const Text('Turn Speed (deg/s)'),
                                 trailing: Text(
-                                  widget.t1TurnSpeed.toString(),
+                                  widget.t1TurnSpeed.toStringAsFixed(3),
                                   style: const TextStyle(fontSize: 15),
                                 ),
                               ),
@@ -368,7 +368,7 @@ class _DynamicResultsPage extends State<DynamicResultsPage> {
                                   'ML Sway (cm/s\u00B2)',
                                 ),
                                 trailing: Text(
-                                  widget.t1MLSway.toString(),
+                                  (widget.t1MLSway * 100).toStringAsFixed(3),
                                   style: const TextStyle(fontSize: 15),
                                 ),
                               ),
@@ -406,14 +406,14 @@ class _DynamicResultsPage extends State<DynamicResultsPage> {
                               ListTile(
                                 title: const Text('Duration (s)'),
                                 trailing: Text(
-                                  widget.t2Duration.toString(),
+                                  widget.t2Duration.toStringAsFixed(3),
                                   style: const TextStyle(fontSize: 15),
                                 ),
                               ),
                               ListTile(
                                 title: const Text('Turn Speed (deg/s)'),
                                 trailing: Text(
-                                  widget.t2TurnSpeed.toString(),
+                                  widget.t2TurnSpeed.toStringAsFixed(3),
                                   style: const TextStyle(fontSize: 15),
                                 ),
                               ),
@@ -422,7 +422,7 @@ class _DynamicResultsPage extends State<DynamicResultsPage> {
                                   'ML Sway (cm/s\u00B2)',
                                 ),
                                 trailing: Text(
-                                  widget.t2MLSway.toString(),
+                                  (widget.t2MLSway * 100).toStringAsFixed(3),
                                   style: const TextStyle(fontSize: 15),
                                 ),
                               ),
@@ -460,14 +460,14 @@ class _DynamicResultsPage extends State<DynamicResultsPage> {
                               ListTile(
                                 title: const Text('Duration (s)'),
                                 trailing: Text(
-                                  widget.t3Duration.toString(),
+                                  widget.t3Duration.toStringAsFixed(3),
                                   style: const TextStyle(fontSize: 15),
                                 ),
                               ),
                               ListTile(
                                 title: const Text('Turn Speed (deg/s)'),
                                 trailing: Text(
-                                  widget.t3TurnSpeed.toString(),
+                                  widget.t3TurnSpeed.toStringAsFixed(3),
                                   style: const TextStyle(fontSize: 15),
                                 ),
                               ),
@@ -476,7 +476,7 @@ class _DynamicResultsPage extends State<DynamicResultsPage> {
                                   'ML Sway (cm/s\u00B2)',
                                 ),
                                 trailing: Text(
-                                  widget.t3MLSway.toString(),
+                                  (widget.t3MLSway * 100).toStringAsFixed(3),
                                   style: const TextStyle(fontSize: 15),
                                 ),
                               ),

--- a/u_react/lib/dynamic_test_page.dart
+++ b/u_react/lib/dynamic_test_page.dart
@@ -217,9 +217,7 @@ class _DynamicTestPage extends State<DynamicTestPage> {
     // Values for duration
     double dMax = max(widget.t1Duration, max(widget.t2Duration, duration));
     double dMin = min(widget.t1Duration, min(widget.t2Duration, duration));
-    double dMean = double.parse(
-        ((widget.t1Duration + widget.t2Duration + duration) / 3)
-            .toStringAsFixed(3));
+    double dMean = (widget.t1Duration + widget.t2Duration + duration) / 3;
     double dMedian;
     if ((widget.t1Duration <= widget.t2Duration) &&
         (widget.t2Duration <= duration)) {
@@ -244,9 +242,8 @@ class _DynamicTestPage extends State<DynamicTestPage> {
         max(widget.t1TurnSpeed, max(widget.t2TurnSpeed, turningSpeed));
     double tsMin =
         min(widget.t1TurnSpeed, min(widget.t2TurnSpeed, turningSpeed));
-    double tsMean = double.parse(
-        ((widget.t1TurnSpeed + widget.t2TurnSpeed + turningSpeed) / 3)
-            .toStringAsFixed(3));
+    double tsMean =
+        (widget.t1TurnSpeed + widget.t2TurnSpeed + turningSpeed) / 3;
     double tsMedian;
     if ((widget.t1TurnSpeed <= widget.t2TurnSpeed) &&
         (widget.t2TurnSpeed <= turningSpeed)) {
@@ -269,8 +266,7 @@ class _DynamicTestPage extends State<DynamicTestPage> {
     // Values for ML
     double mlMax = max(widget.t1MLSway, max(widget.t2MLSway, mlSway));
     double mlMin = min(widget.t1MLSway, min(widget.t2MLSway, mlSway));
-    double mlMean = double.parse(
-        ((widget.t1MLSway + widget.t2MLSway + mlSway) / 3).toStringAsFixed(3));
+    double mlMean = (widget.t1MLSway + widget.t2MLSway + mlSway) / 3;
     double mlMedian;
     if ((widget.t1MLSway <= widget.t2MLSway) && (widget.t2MLSway <= mlSway)) {
       mlMedian = widget.t2MLSway;
@@ -499,16 +495,10 @@ class _DynamicTestPage extends State<DynamicTestPage> {
 
                               if (context.mounted) {
                                 double duration = data["duration"];
-                                duration =
-                                    double.parse(duration.toStringAsFixed(3));
                                 double turningSpeed = data["turningSpeed"];
-                                turningSpeed = double.parse(
-                                    turningSpeed.toStringAsFixed(3));
                                 double mlSway =
                                     (data["rmsMlGoing"] + data["rmsMlReturn"]) /
                                         2;
-                                mlSway =
-                                    double.parse(mlSway.toStringAsFixed(3));
 
                                 if (duration == 0) {
                                   throwTestError();
@@ -591,20 +581,17 @@ class _DynamicTestPage extends State<DynamicTestPage> {
                                                 createdDynamic.t1Duration,
                                             t1TurnSpeed:
                                                 createdDynamic.t1TurnSpeed,
-                                            t1MLSway:
-                                                createdDynamic.t1MLSway * 100,
+                                            t1MLSway: createdDynamic.t1MLSway,
                                             t2Duration:
                                                 createdDynamic.t2Duration,
                                             t2TurnSpeed:
                                                 createdDynamic.t2TurnSpeed,
-                                            t2MLSway:
-                                                createdDynamic.t2MLSway * 100,
+                                            t2MLSway: createdDynamic.t2MLSway,
                                             t3Duration:
                                                 createdDynamic.t3Duration,
                                             t3TurnSpeed:
                                                 createdDynamic.t3TurnSpeed,
-                                            t3MLSway:
-                                                createdDynamic.t3MLSway * 100,
+                                            t3MLSway: createdDynamic.t3MLSway,
                                             dMax: createdDynamic.dMax,
                                             dMin: createdDynamic.dMin,
                                             dMean: createdDynamic.dMean,
@@ -613,11 +600,10 @@ class _DynamicTestPage extends State<DynamicTestPage> {
                                             tsMin: createdDynamic.tsMin,
                                             tsMean: createdDynamic.tsMean,
                                             tsMedian: createdDynamic.tsMedian,
-                                            mlMax: createdDynamic.mlMax * 100,
-                                            mlMin: createdDynamic.mlMin * 100,
-                                            mlMean: createdDynamic.mlMean * 100,
-                                            mlMedian:
-                                                createdDynamic.mlMedian * 100,
+                                            mlMax: createdDynamic.mlMax,
+                                            mlMin: createdDynamic.mlMin,
+                                            mlMean: createdDynamic.mlMean,
+                                            mlMedian: createdDynamic.mlMedian,
                                             tID: widget.tID,
                                           ),
                                         ),

--- a/u_react/lib/reactive_test_page.dart
+++ b/u_react/lib/reactive_test_page.dart
@@ -284,11 +284,11 @@ class _ReactiveTestPage extends State<ReactiveTestPage> {
                 pID: widget.pID,
                 thirdPartyID: widget.thirdPartyID,
                 administeredBy: createdReactive.administeredBy,
-                forward: widget.forward * 1000,
-                left: widget.left * 1000,
-                right: timeToStab * 1000,
-                backward: widget.backward * 1000,
-                median: normMedian * 1000,
+                forward: widget.forward,
+                left: widget.left,
+                right: timeToStab,
+                backward: widget.backward,
+                median: normMedian,
                 tID: widget.tID,
               ),
             ),
@@ -327,8 +327,7 @@ class _ReactiveTestPage extends State<ReactiveTestPage> {
     } else {
       median = vals[0];
     }
-    double normMedian = double.parse(median.toStringAsFixed(2));
-    return normMedian;
+    return median;
   }
 
   void skip() async {
@@ -356,7 +355,7 @@ class _ReactiveTestPage extends State<ReactiveTestPage> {
                 left: widget.left,
                 right: widget.right,
                 backward: widget.backward,
-                median: double.parse(median.toStringAsFixed(2)),
+                median: median,
                 tID: widget.tID,
               ),
             ),

--- a/u_react/lib/reactive_test_results_page.dart
+++ b/u_react/lib/reactive_test_results_page.dart
@@ -120,7 +120,7 @@ class _TestResultsPageState extends State<ReactiveTestResultsPage> {
                           ),
                         ),
                         trailing: Text(
-                          "${widget.median.toInt().toString()} ms",
+                          "${widget.median.toStringAsFixed(3)} s",
                           style: const TextStyle(fontSize: 15),
                         ),
                       ),
@@ -152,7 +152,7 @@ class _TestResultsPageState extends State<ReactiveTestResultsPage> {
                           ),
                         ),
                         trailing: Text(
-                          "${widget.forward.toInt().toString()} ms",
+                          "${widget.forward.toStringAsFixed(3)} s",
                           style: const TextStyle(fontSize: 15),
                         ),
                       ),
@@ -184,7 +184,7 @@ class _TestResultsPageState extends State<ReactiveTestResultsPage> {
                           ),
                         ),
                         trailing: Text(
-                          "${widget.backward.toInt().toString()} ms",
+                          "${widget.backward.toStringAsFixed(3)} s",
                           style: const TextStyle(fontSize: 15),
                         ),
                       ),
@@ -216,7 +216,7 @@ class _TestResultsPageState extends State<ReactiveTestResultsPage> {
                           ),
                         ),
                         trailing: Text(
-                          "${widget.left.toInt().toString()} ms",
+                          "${widget.left.toStringAsFixed(3)} s",
                           style: const TextStyle(fontSize: 15),
                         ),
                       ),
@@ -248,7 +248,7 @@ class _TestResultsPageState extends State<ReactiveTestResultsPage> {
                           ),
                         ),
                         trailing: Text(
-                          "${widget.right.toInt().toString()} ms",
+                          "${widget.right.toStringAsFixed(3)} s",
                           style: const TextStyle(fontSize: 15),
                         ),
                       ),

--- a/u_react/lib/static_results_page.dart
+++ b/u_react/lib/static_results_page.dart
@@ -45,6 +45,7 @@ class _StaticResultsPage extends State<StaticResultsPage> {
 
   @override
   Widget build(BuildContext context) {
+    print(widget.slSolidML);
     return MaterialApp(
       title: 'Test Results',
       theme: ThemeData(
@@ -124,7 +125,7 @@ class _StaticResultsPage extends State<StaticResultsPage> {
                           ),
                         ),
                         trailing: Text(
-                          "${widget.tlSolidML.toStringAsFixed(3)} cm/s\u00B2",
+                          "${(widget.tlSolidML * 100).toStringAsFixed(3)} cm/s\u00B2",
                           style: const TextStyle(fontSize: 15),
                         ),
                       ),
@@ -156,7 +157,7 @@ class _StaticResultsPage extends State<StaticResultsPage> {
                           ),
                         ),
                         trailing: Text(
-                          "${widget.tandSolidML.toStringAsFixed(3)} cm/s\u00B2",
+                          "${(widget.tandSolidML * 100).toStringAsFixed(3)} cm/s\u00B2",
                           style: const TextStyle(fontSize: 15),
                         ),
                       ),
@@ -188,7 +189,7 @@ class _StaticResultsPage extends State<StaticResultsPage> {
                           ),
                         ),
                         trailing: Text(
-                          "${widget.slSolidML.toStringAsFixed(3)} cm/s\u00B2",
+                          "${(widget.slSolidML * 100).toStringAsFixed(3)} cm/s\u00B2",
                           style: const TextStyle(fontSize: 15),
                         ),
                       ),
@@ -234,7 +235,7 @@ class _StaticResultsPage extends State<StaticResultsPage> {
                           ),
                         ),
                         trailing: Text(
-                          "${widget.tlFoamML.toStringAsFixed(3)} cm/s\u00B2",
+                          "${(widget.tlFoamML * 100).toStringAsFixed(3)} cm/s\u00B2",
                           style: const TextStyle(fontSize: 15),
                         ),
                       ),
@@ -266,7 +267,7 @@ class _StaticResultsPage extends State<StaticResultsPage> {
                           ),
                         ),
                         trailing: Text(
-                          "${widget.tandFoamML.toStringAsFixed(3)} cm/s\u00B2",
+                          "${(widget.tandFoamML * 100).toStringAsFixed(3)} cm/s\u00B2",
                           style: const TextStyle(fontSize: 15),
                         ),
                       ),
@@ -298,7 +299,7 @@ class _StaticResultsPage extends State<StaticResultsPage> {
                           ),
                         ),
                         trailing: Text(
-                          "${widget.slFoamML.toStringAsFixed(3)} cm/s\u00B2",
+                          "${(widget.slFoamML * 100).toStringAsFixed(3)} cm/s\u00B2",
                           style: const TextStyle(fontSize: 15),
                         ),
                       ),

--- a/u_react/lib/static_test_page.dart
+++ b/u_react/lib/static_test_page.dart
@@ -206,7 +206,7 @@ class _StaticTestPage extends State<StaticTestPage> {
         "slSolidML": widget.slSolidML,
         "slFoamML": widget.slFoamML,
         "tandSolidML": widget.tandSolidML,
-        "tandFoamML": double.parse(dataML.toStringAsFixed(2)),
+        "tandFoamML": dataML,
         "tID": widget.tID,
       });
       Static staticTest = Static.fromJson(jsonStatic);
@@ -219,7 +219,7 @@ class _StaticTestPage extends State<StaticTestPage> {
   Future stopRecording() async {
     timer!.cancel();
     dynamic dataML = await getStaticData();
-    double mlSway = double.parse(dataML.toStringAsFixed(5));
+    double mlSway = dataML;
     if (context.mounted) {
       if (widget.stance == "Two Leg Stance (Solid)") {
         Navigator.pushReplacement(
@@ -444,12 +444,12 @@ class _StaticTestPage extends State<StaticTestPage> {
                   thirdPartyID: widget.thirdPartyID,
                   administeredBy: createdStatic.administeredBy,
                   tID: widget.tID,
-                  tlSolidML: widget.tlSolidML * 100,
-                  tlFoamML: widget.tlFoamML * 100,
-                  slSolidML: widget.slSolidML * 100,
-                  slFoamML: widget.slFoamML * 100,
-                  tandSolidML: widget.tandSolidML * 100,
-                  tandFoamML: mlSway * 100,
+                  tlSolidML: widget.tlSolidML,
+                  tlFoamML: widget.tlFoamML,
+                  slSolidML: widget.slSolidML,
+                  slFoamML: widget.slFoamML,
+                  tandSolidML: widget.tandSolidML,
+                  tandFoamML: mlSway,
                 ),
               ),
             );

--- a/u_react/lib/tests_page.dart
+++ b/u_react/lib/tests_page.dart
@@ -455,12 +455,11 @@ class _TestsPage extends State<TestsPage> {
                                       thirdPartyID: widget.thirdPartyID,
                                       administeredBy:
                                           test!.reactiveTest!.administeredBy,
-                                      backward:
-                                          test!.reactiveTest!.bTime * 1000,
-                                      forward: test!.reactiveTest!.fTime * 1000,
-                                      left: test!.reactiveTest!.lTime * 1000,
-                                      right: test!.reactiveTest!.rTime * 1000,
-                                      median: test!.reactiveTest!.mTime * 1000,
+                                      backward: test!.reactiveTest!.bTime,
+                                      forward: test!.reactiveTest!.fTime,
+                                      left: test!.reactiveTest!.lTime,
+                                      right: test!.reactiveTest!.rTime,
+                                      median: test!.reactiveTest!.mTime,
                                       tID: test!.tID,
                                     ),
                                   ),
@@ -506,38 +505,30 @@ class _TestsPage extends State<TestsPage> {
                                       thirdPartyID: widget.thirdPartyID,
                                       administeredBy:
                                           test!.dynamicTest!.administeredBy,
-                                      t1Duration:
-                                          test!.dynamicTest!.t1Duration * 1000,
+                                      t1Duration: test!.dynamicTest!.t1Duration,
                                       t1TurnSpeed:
                                           test!.dynamicTest!.t1TurnSpeed,
-                                      t1MLSway:
-                                          test!.dynamicTest!.t1MLSway * 100,
-                                      t2Duration:
-                                          test!.dynamicTest!.t2Duration * 1000,
+                                      t1MLSway: test!.dynamicTest!.t1MLSway,
+                                      t2Duration: test!.dynamicTest!.t2Duration,
                                       t2TurnSpeed:
                                           test!.dynamicTest!.t2TurnSpeed,
-                                      t2MLSway:
-                                          test!.dynamicTest!.t2MLSway * 100,
-                                      t3Duration:
-                                          test!.dynamicTest!.t3Duration * 1000,
+                                      t2MLSway: test!.dynamicTest!.t2MLSway,
+                                      t3Duration: test!.dynamicTest!.t3Duration,
                                       t3TurnSpeed:
                                           test!.dynamicTest!.t3TurnSpeed,
-                                      t3MLSway:
-                                          test!.dynamicTest!.t3MLSway * 100,
-                                      dMax: test!.dynamicTest!.dMax * 1000,
-                                      dMin: test!.dynamicTest!.dMin * 1000,
-                                      dMean: test!.dynamicTest!.dMean * 1000,
-                                      dMedian:
-                                          test!.dynamicTest!.dMedian * 1000,
+                                      t3MLSway: test!.dynamicTest!.t3MLSway,
+                                      dMax: test!.dynamicTest!.dMax,
+                                      dMin: test!.dynamicTest!.dMin,
+                                      dMean: test!.dynamicTest!.dMean,
+                                      dMedian: test!.dynamicTest!.dMedian,
                                       tsMax: test!.dynamicTest!.tsMax,
                                       tsMin: test!.dynamicTest!.tsMin,
                                       tsMean: test!.dynamicTest!.tsMean,
                                       tsMedian: test!.dynamicTest!.tsMedian,
-                                      mlMax: test!.dynamicTest!.mlMax * 100,
-                                      mlMin: test!.dynamicTest!.mlMin * 100,
-                                      mlMean: test!.dynamicTest!.mlMean * 100,
-                                      mlMedian:
-                                          test!.dynamicTest!.mlMedian * 100,
+                                      mlMax: test!.dynamicTest!.mlMax,
+                                      mlMin: test!.dynamicTest!.mlMin,
+                                      mlMean: test!.dynamicTest!.mlMean,
+                                      mlMedian: test!.dynamicTest!.mlMedian,
                                       tID: widget.tID,
                                     ),
                                   ),
@@ -581,7 +572,6 @@ class _TestsPage extends State<TestsPage> {
                             if (!editMode) {
                               // check if static exists
                               if (test!.staticTest != null) {
-                                print(test!.staticTest!.sID);
                                 Navigator.pushReplacement(
                                   context,
                                   MaterialPageRoute(
@@ -591,18 +581,13 @@ class _TestsPage extends State<TestsPage> {
                                       administeredBy:
                                           test!.staticTest!.administeredBy,
                                       tID: widget.tID,
-                                      tlSolidML:
-                                          test!.staticTest!.tlSolidML * 100,
-                                      tlFoamML:
-                                          test!.staticTest!.tlFoamML * 100,
-                                      slSolidML:
-                                          test!.staticTest!.slSolidML * 100,
-                                      slFoamML:
-                                          test!.staticTest!.slSolidML * 100,
+                                      tlSolidML: test!.staticTest!.tlSolidML,
+                                      tlFoamML: test!.staticTest!.tlFoamML,
+                                      slSolidML: test!.staticTest!.slSolidML,
+                                      slFoamML: test!.staticTest!.slSolidML,
                                       tandSolidML:
-                                          test!.staticTest!.tandSolidML * 100,
-                                      tandFoamML:
-                                          test!.staticTest!.tandFoamML * 100,
+                                          test!.staticTest!.tandSolidML,
+                                      tandFoamML: test!.staticTest!.tandFoamML,
                                     ),
                                   ),
                                 );


### PR DESCRIPTION
Completely revised the way units are converted and displayed. The raw data is stored in the database. The conversions only happen on the results pages for Reactive, Dynamic, and Static. 

- Time is displayed in seconds (no conversion needed)
- Turn speed in deg/s (no conversion needed)
- ML Sway in cm/s^2 (multiplied by 100)